### PR TITLE
kube-cluster-autoscaler: Update to version v1.18.2-internal.49

### DIFF
--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.47
+        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.48
         command:
           - ./cluster-autoscaler
           - --v={{.Cluster.ConfigItems.autoscaling_autoscaler_log_level}}

--- a/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
+++ b/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cluster-autoscaler
-        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.48
+        image: container-registry.zalando.net/teapot/kube-cluster-autoscaler:v1.18.2-internal.49
         command:
           - ./cluster-autoscaler
           - --v={{.Cluster.ConfigItems.autoscaling_autoscaler_log_level}}


### PR DESCRIPTION
* Use static base image for CA (https://github.com/zalando-incubator/autoscaler/pull/112)
* Use static base image for CA (https://github.com/zalando-incubator/autoscaler/pull/112)