### PR TITLE
kube-metrics-adapter: Update to version v0.2.2-38-g7cd565c

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: container-registry.zalando.net/teapot/kube-metrics-adapter:kube-metrics-adapter-0.2.3-3-g8245fbe
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:v0.2.2-38-g7cd565c
         env:
         - name: AWS_REGION
           value: {{ .Cluster.Region }}


### PR DESCRIPTION
* Bump golang.org/x/net from 0.23.0 to 0.24.0 (https://github.com/zalando-incubator/kube-metrics-adapter/pull/703)