### PR TITLE
vpa-updater: Update to version v1.1.2-main-4-custom

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/updater-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
         image: container-registry.zalando.net/teapot/vpa-updater:v1.1.2-main-5-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-updater:v1.1.2-main-2-custom
+        image: container-registry.zalando.net/teapot/vpa-updater:v1.1.2-main-4-custom
         {{end}}
         command:
           - ./updater


### PR DESCRIPTION
* Use zalando Static base image and latest Go (https://github.bus.zalan.do/teapot/vertical-pod-autoscaler-pipeline/pull/5)