### PR TITLE
aws-node-decommissioner: Update to version master-dacee4e8-master-16

### DIFF
--- a/cluster/manifests/aws-node-decommissioner/cronjob.yaml
+++ b/cluster/manifests/aws-node-decommissioner/cronjob.yaml
@@ -28,7 +28,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: aws-node-decommissioner
-            image: container-registry.zalando.net/teapot/aws-node-decommissioner:master-690846a9-master-17
+            image: container-registry.zalando.net/teapot/aws-node-decommissioner:master-dacee4e8-master-16
             args:
               - --debug
             resources:


### PR DESCRIPTION
* Drop building image for pierone (https://github.bus.zalan.do/teapot/aws-node-decommissioner-pipeline/pull/12)