### PR TITLE
k8s-dns-dnsmasq-nanny: Update to version 1.23.1-master-17

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -92,7 +92,7 @@ spec:
 {{ end }}
 {{ if eq .Cluster.ConfigItems.dns_cache "dnsmasq" }}
       - name: dnsmasq
-        image: container-registry.zalando.net/teapot/k8s-dns-dnsmasq-nanny:1.17.4-master-15
+        image: container-registry.zalando.net/teapot/k8s-dns-dnsmasq-nanny:1.23.1-master-17
         securityContext:
           privileged: true
         livenessProbe:


### PR DESCRIPTION
* Update to 1.23.1 (https://github.bus.zalan.do/teapot/k8s-dns-kube-dns-pipeline/pull/16)