### PR TITLE
k8s-dns-sidecar: Update to version 1.23.1-master-17

### DIFF
--- a/cluster/manifests/coredns-local/daemonset-coredns.yaml
+++ b/cluster/manifests/coredns-local/daemonset-coredns.yaml
@@ -134,7 +134,7 @@ spec:
             cpu: {{.Cluster.ConfigItems.dns_dnsmasq_cpu}}
             memory: {{.Cluster.ConfigItems.dns_dnsmasq_mem}}
       - name: sidecar
-        image: container-registry.zalando.net/teapot/k8s-dns-sidecar:1.17.4-master-15
+        image: container-registry.zalando.net/teapot/k8s-dns-sidecar:1.23.1-master-17
         securityContext:
           privileged: true
         livenessProbe:


### PR DESCRIPTION
* Update to 1.23.1 (https://github.bus.zalan.do/teapot/k8s-dns-kube-dns-pipeline/pull/16)