### PR TITLE
prometheus: Update to version v2.53.1-master-56

### DIFF
--- a/cluster/manifests/kubenurse/prometheus.yaml
+++ b/cluster/manifests/kubenurse/prometheus.yaml
@@ -37,7 +37,7 @@ spec:
           value: "1"
       containers:
       - name: prometheus
-        image: container-registry.zalando.net/teapot/prometheus:v2.41.0-master-43
+        image: container-registry.zalando.net/teapot/prometheus:v2.53.0-master-55
         args:
         - "--config.file=/etc/prometheus/prometheus.yml"
         - "--storage.tsdb.path=/prometheus/"

--- a/cluster/manifests/kubenurse/prometheus.yaml
+++ b/cluster/manifests/kubenurse/prometheus.yaml
@@ -37,7 +37,7 @@ spec:
           value: "1"
       containers:
       - name: prometheus
-        image: container-registry.zalando.net/teapot/prometheus:v2.53.0-master-55
+        image: container-registry.zalando.net/teapot/prometheus:v2.53.1-master-56
         args:
         - "--config.file=/etc/prometheus/prometheus.yml"
         - "--storage.tsdb.path=/prometheus/"


### PR DESCRIPTION
* Update to Prometheus v2.53.0 (https://github.bus.zalan.do/teapot/prometheus-pipeline/pull/56)
* Update to Prometheus v2.53.1 (https://github.bus.zalan.do/teapot/prometheus-pipeline/pull/57)