### PR TITLE
nvidia-dcgm-exporter: Update to version v3.3.6-3.4.2-ubuntu22.04-master-12

### DIFF
--- a/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
+++ b/cluster/manifests/nvidia/nvidia-gpu-device-plugin.yaml
@@ -80,7 +80,7 @@ spec:
           mountPath: /var/lib/kubelet/device-plugins
 {{- if eq .Cluster.ConfigItems.nvidia_dcgm_exporter_enabled "true" }}
       - name: dcgm-exporter
-        image: container-registry.zalando.net/teapot/nvidia-dcgm-exporter:v3.3.6-3.4.2-ubuntu22.04-master-11
+        image: container-registry.zalando.net/teapot/nvidia-dcgm-exporter:v3.3.6-3.4.2-ubuntu22.04-master-12
         args:
         - --kubernetes
         - --address=:9400


### PR DESCRIPTION
* Update device plugin to v0.15.0 (https://github.bus.zalan.do/teapot/nvidia-gpu-device-plugin-pipeline/pull/11)