### PR TITLE
amazonlinux-2023-slim: Update to version main-821.1142-20240717

### DIFF
--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
           value: "1"
       initContainers:
       - name: generate-config
-        image: container-registry.zalando.net/library/amazonlinux-2023-slim:main-817.1138-20240711
+        image: container-registry.zalando.net/library/amazonlinux-2023-slim:main-819.1140-20240715
         command:
         - /bin/bash
         args:

--- a/cluster/manifests/prometheus/statefulset.yaml
+++ b/cluster/manifests/prometheus/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
           value: "1"
       initContainers:
       - name: generate-config
-        image: container-registry.zalando.net/library/amazonlinux-2023-slim:main-819.1140-20240715
+        image: container-registry.zalando.net/library/amazonlinux-2023-slim:main-821.1142-20240717
         command:
         - /bin/bash
         args:


### PR DESCRIPTION
* fix entrypoint (https://github.bus.zalan.do/docker-base-images/amazonlinux/pull/88)
* fix entrypoint (https://github.bus.zalan.do/docker-base-images/amazonlinux/pull/88)