### PR TITLE
redis-7-alpine: Update to version 7.2-alpine-20240715

### DIFF
--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -49,7 +49,7 @@ spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       terminationGracePeriodSeconds: 45
       containers:
-      - image: container-registry.zalando.net/library/redis-7-alpine:7-alpine-20240226
+      - image: container-registry.zalando.net/library/redis-7-alpine:7-alpine-20240605
         name: skipper-ingress-redis
         args:
         - /usr/local/bin/docker-entrypoint.sh

--- a/cluster/manifests/skipper/skipper-redis.yaml
+++ b/cluster/manifests/skipper/skipper-redis.yaml
@@ -49,7 +49,7 @@ spec:
       priorityClassName: "{{ .Cluster.ConfigItems.system_priority_class }}"
       terminationGracePeriodSeconds: 45
       containers:
-      - image: container-registry.zalando.net/library/redis-7-alpine:7-alpine-20240605
+      - image: container-registry.zalando.net/library/redis-7-alpine:7.2-alpine-20240715
         name: skipper-ingress-redis
         args:
         - /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
* Upgrade Keycloak To Version 24 (https://github.bus.zalan.do/docker-base-images/allowed-docker-images/pull/480)
* ES & Kibana 8.14.3 (https://github.bus.zalan.do/docker-base-images/allowed-docker-images/pull/489)