### PR TITLE
vpa-admission-controller: Update to version v1.1.2-main-5-custom

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/admission-controller-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
         image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.1.2-main-5-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.1.2-main-2-custom
+        image: container-registry.zalando.net/teapot/vpa-admission-controller:v1.1.2-main-5-custom
         {{end}}
         command:
           - /admission-controller


### PR DESCRIPTION
* Add patch updating vulnerable modules (https://github.bus.zalan.do/teapot/vertical-pod-autoscaler-pipeline/pull/4)