### PR TITLE
vpa-recommender: Update to version v1.1.2-main-5-custom

### DIFF
--- a/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
+++ b/cluster/manifests/01-vertical-pod-autoscaler/recommender-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         {{if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "current"}}
         image: container-registry.zalando.net/teapot/vpa-recommender:v1.1.2-main-5-custom
         {{else if eq .Cluster.ConfigItems.vertical_pod_autoscaler_version "legacy"}}
-        image: container-registry.zalando.net/teapot/vpa-recommender:v1.1.2-main-2-custom
+        image: container-registry.zalando.net/teapot/vpa-recommender:v1.1.2-main-5-custom
         {{end}}
         args:
         - --logtostderr


### PR DESCRIPTION
* Add patch updating vulnerable modules (https://github.bus.zalan.do/teapot/vertical-pod-autoscaler-pipeline/pull/4)