### PR TITLE
kube-metrics-adapter: Update to version kube-metrics-adapter-0.2.3-14-g06e0010

### DIFF
--- a/cluster/manifests/kube-metrics-adapter/deployment.yaml
+++ b/cluster/manifests/kube-metrics-adapter/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: kube-metrics-adapter
-        image: container-registry.zalando.net/teapot/kube-metrics-adapter:kube-metrics-adapter-0.2.3-3-g8245fbe
+        image: container-registry.zalando.net/teapot/kube-metrics-adapter:kube-metrics-adapter-0.2.3-14-g06e0010
         env:
         - name: AWS_REGION
           value: {{ .Cluster.Region }}


### PR DESCRIPTION
* Bump the all-go-mod-patch-and-minor group with 3 updates (https://github.com/zalando-incubator/kube-metrics-adapter/pull/741)