### PR TITLE
prometheus-node-exporter: Update to version v1.8.2-master-22

### DIFF
--- a/cluster/manifests/node-monitor/daemonset.yaml
+++ b/cluster/manifests/node-monitor/daemonset.yaml
@@ -79,7 +79,7 @@ spec:
               hostPort: 9101
               protocol: TCP
 {{- end }}
-        - image: container-registry.zalando.net/teapot/prometheus-node-exporter:v1.8.1-master-21
+        - image: container-registry.zalando.net/teapot/prometheus-node-exporter:v1.8.2-master-22
           args:
 {{- if eq .Cluster.ConfigItems.node_exporter_experimental_metrics "true" }}
             - --collector.ethtool


### PR DESCRIPTION
* Update to node-exporter 1.8.2 (https://github.bus.zalan.do/teapot/prometheus-node-exporter-pipeline/pull/21)