### PR TITLE
karpenter: Update to version 0.37.0-main-26.patched

### DIFF
--- a/cluster/manifests/z-karpenter/deployment.yaml
+++ b/cluster/manifests/z-karpenter/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           {{if eq .Cluster.ConfigItems.karpenter_version "current"}}
           image: "container-registry.zalando.net/teapot/karpenter:0.37.0-main-26.patched"
           {{else if eq .Cluster.ConfigItems.karpenter_version "legacy"}}
-          image: "container-registry.zalando.net/teapot/karpenter:0.36.2-main-25.patched"
+          image: "container-registry.zalando.net/teapot/karpenter:0.37.0-main-26.patched"
           {{end}}
           imagePullPolicy: IfNotPresent
           env:


### PR DESCRIPTION
* Update to Karpenter v0.37.0 (https://github.bus.zalan.do/teapot/karpenter-pipeline/pull/25)